### PR TITLE
Search `/usr/include` for CUDA 10.1 headers

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,13 @@ source:
 build:
   number: 0
   skip: True  # [not (linux64 and cuda_compiler_version != "None")]
-  script: "{{ PYTHON }} -m pip install . -vv"
+  script:
+    # CUDA 10.1 moves some headers to `/usr/include`
+    # So add that location last in the header search paths
+    - export CFLAGS="${CFLAGS} -I/usr/include"
+    - export CPPFLAGS="${CPPFLAGS} -I/usr/include"
+    - export CXXFLAGS="${CXXFLAGS} -I/usr/include"
+    - "{{ PYTHON }} -m pip install . -vv"
   missing_dso_whitelist:
     - "*/libcuda.*"
 


### PR DESCRIPTION
As CUDA 10.1 moves some headers and libraries from `/usr/local/cuda` to `/usr`, we need to adjust our search strategy for finding them. Since `cudatoolkit` already contains the libraries and is available during the build, this is less of an issue. However we still need to point the compiler to the headers in `/usr/include`. Thus we add `/usr/include` to our compiler flags. To avoid clobbering other search paths we care about, we make sure to add `/usr/include` last. As we are not searching `/usr/lib64`, this shouldn't result in any accidental linkages against system libraries.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes https://github.com/conda-forge/cupy-feedstock/issues/3

<!--
Please add any other relevant info below:
-->
