### PR TITLE
Print `ImportError` message during package testing

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: True  # [(not linux64) or cuda_compiler_version == "None"]
   script:
     # CUDA 10.1 moves some headers to `/usr/include`

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -12,6 +12,7 @@ try:
     import cupy
 except ImportError as e:
     print("No GPU available. Exiting without running CuPy's tests.")
+    print('Got ImportError: "%s"' % str(e))
     sys.exit(0)
 
 # Run CuPy's test suite

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -10,7 +10,7 @@ pkgutil.find_loader("cupy")
 import sys
 try:
     import cupy
-except ImportError:
+except ImportError as e:
     print("No GPU available. Exiting without running CuPy's tests.")
     sys.exit(0)
 


### PR DESCRIPTION
In the event a user wants to test the CuPy package on hardware, but gets an unexpected `ImportError`, it would be useful to share exactly why importing failed. Should give users a bit more information to aid in debugging the issue.

cc @mariusvniekerk @leofang

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes https://github.com/conda-forge/cupy-feedstock/issues/6

<!--
Please add any other relevant info below:
-->
