### PR TITLE
Re-enable CUB support

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -10,52 +10,52 @@ jobs:
   strategy:
     maxParallel: 8
     matrix:
-      linux_cuda_compiler_version10.0python3.6:
-        CONFIG: linux_cuda_compiler_version10.0python3.6
+      linux_cuda_compiler_version10.0python3.6.____cpython:
+        CONFIG: linux_cuda_compiler_version10.0python3.6.____cpython
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.0
-      linux_cuda_compiler_version10.0python3.7:
-        CONFIG: linux_cuda_compiler_version10.0python3.7
+      linux_cuda_compiler_version10.0python3.7.____cpython:
+        CONFIG: linux_cuda_compiler_version10.0python3.7.____cpython
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.0
-      linux_cuda_compiler_version10.0python3.8:
-        CONFIG: linux_cuda_compiler_version10.0python3.8
+      linux_cuda_compiler_version10.0python3.8.____cpython:
+        CONFIG: linux_cuda_compiler_version10.0python3.8.____cpython
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.0
-      linux_cuda_compiler_version10.1python3.6:
-        CONFIG: linux_cuda_compiler_version10.1python3.6
+      linux_cuda_compiler_version10.1python3.6.____cpython:
+        CONFIG: linux_cuda_compiler_version10.1python3.6.____cpython
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.1
-      linux_cuda_compiler_version10.1python3.7:
-        CONFIG: linux_cuda_compiler_version10.1python3.7
+      linux_cuda_compiler_version10.1python3.7.____cpython:
+        CONFIG: linux_cuda_compiler_version10.1python3.7.____cpython
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.1
-      linux_cuda_compiler_version10.1python3.8:
-        CONFIG: linux_cuda_compiler_version10.1python3.8
+      linux_cuda_compiler_version10.1python3.8.____cpython:
+        CONFIG: linux_cuda_compiler_version10.1python3.8.____cpython
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.1
-      linux_cuda_compiler_version10.2python3.6:
-        CONFIG: linux_cuda_compiler_version10.2python3.6
+      linux_cuda_compiler_version10.2python3.6.____cpython:
+        CONFIG: linux_cuda_compiler_version10.2python3.6.____cpython
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.2
-      linux_cuda_compiler_version10.2python3.7:
-        CONFIG: linux_cuda_compiler_version10.2python3.7
+      linux_cuda_compiler_version10.2python3.7.____cpython:
+        CONFIG: linux_cuda_compiler_version10.2python3.7.____cpython
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.2
-      linux_cuda_compiler_version10.2python3.8:
-        CONFIG: linux_cuda_compiler_version10.2python3.8
+      linux_cuda_compiler_version10.2python3.8.____cpython:
+        CONFIG: linux_cuda_compiler_version10.2python3.8.____cpython
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.2
-      linux_cuda_compiler_version9.2python3.6:
-        CONFIG: linux_cuda_compiler_version9.2python3.6
+      linux_cuda_compiler_version9.2python3.6.____cpython:
+        CONFIG: linux_cuda_compiler_version9.2python3.6.____cpython
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-cuda:9.2
-      linux_cuda_compiler_version9.2python3.7:
-        CONFIG: linux_cuda_compiler_version9.2python3.7
+      linux_cuda_compiler_version9.2python3.7.____cpython:
+        CONFIG: linux_cuda_compiler_version9.2python3.7.____cpython
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-cuda:9.2
-      linux_cuda_compiler_version9.2python3.8:
-        CONFIG: linux_cuda_compiler_version9.2python3.8
+      linux_cuda_compiler_version9.2python3.8.____cpython:
+        CONFIG: linux_cuda_compiler_version9.2python3.8.____cpython
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-cuda:9.2
   steps:

--- a/.ci_support/linux_cuda_compiler_version10.0python3.6.____cpython.yaml
+++ b/.ci_support/linux_cuda_compiler_version10.0python3.6.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '10.2'
+- '10.0'
 cudnn:
 - 7.6.5
 cxx_compiler:
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-cuda:10.2
+- condaforge/linux-anvil-cuda:10.0
 nccl:
 - 2.4.6.1
 pin_run_as_build:
@@ -28,7 +28,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- '3.6'
+- 3.6.* *_cpython
 zip_keys:
 - - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_cuda_compiler_version10.0python3.7.____cpython.yaml
+++ b/.ci_support/linux_cuda_compiler_version10.0python3.7.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '10.2'
+- '10.0'
 cudnn:
 - 7.6.5
 cxx_compiler:
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-cuda:10.2
+- condaforge/linux-anvil-cuda:10.0
 nccl:
 - 2.4.6.1
 pin_run_as_build:
@@ -28,7 +28,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- '3.8'
+- 3.7.* *_cpython
 zip_keys:
 - - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_cuda_compiler_version10.0python3.8.____cpython.yaml
+++ b/.ci_support/linux_cuda_compiler_version10.0python3.8.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '10.1'
+- '10.0'
 cudnn:
 - 7.6.5
 cxx_compiler:
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-cuda:10.1
+- condaforge/linux-anvil-cuda:10.0
 nccl:
 - 2.4.6.1
 pin_run_as_build:
@@ -28,7 +28,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- '3.8'
+- 3.8.* *_cpython
 zip_keys:
 - - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_cuda_compiler_version10.1python3.6.____cpython.yaml
+++ b/.ci_support/linux_cuda_compiler_version10.1python3.6.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '9.2'
+- '10.1'
 cudnn:
 - 7.6.5
 cxx_compiler:
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-cuda:9.2
+- condaforge/linux-anvil-cuda:10.1
 nccl:
 - 2.4.6.1
 pin_run_as_build:
@@ -28,7 +28,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- '3.7'
+- 3.6.* *_cpython
 zip_keys:
 - - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_cuda_compiler_version10.1python3.7.____cpython.yaml
+++ b/.ci_support/linux_cuda_compiler_version10.1python3.7.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '10.2'
+- '10.1'
 cudnn:
 - 7.6.5
 cxx_compiler:
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-cuda:10.2
+- condaforge/linux-anvil-cuda:10.1
 nccl:
 - 2.4.6.1
 pin_run_as_build:
@@ -28,7 +28,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- '3.7'
+- 3.7.* *_cpython
 zip_keys:
 - - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_cuda_compiler_version10.1python3.8.____cpython.yaml
+++ b/.ci_support/linux_cuda_compiler_version10.1python3.8.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '9.2'
+- '10.1'
 cudnn:
 - 7.6.5
 cxx_compiler:
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-cuda:9.2
+- condaforge/linux-anvil-cuda:10.1
 nccl:
 - 2.4.6.1
 pin_run_as_build:
@@ -28,7 +28,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- '3.8'
+- 3.8.* *_cpython
 zip_keys:
 - - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_cuda_compiler_version10.2python3.6.____cpython.yaml
+++ b/.ci_support/linux_cuda_compiler_version10.2python3.6.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '10.0'
+- '10.2'
 cudnn:
 - 7.6.5
 cxx_compiler:
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-cuda:10.0
+- condaforge/linux-anvil-cuda:10.2
 nccl:
 - 2.4.6.1
 pin_run_as_build:
@@ -28,7 +28,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- '3.6'
+- 3.6.* *_cpython
 zip_keys:
 - - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_cuda_compiler_version10.2python3.7.____cpython.yaml
+++ b/.ci_support/linux_cuda_compiler_version10.2python3.7.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '9.2'
+- '10.2'
 cudnn:
 - 7.6.5
 cxx_compiler:
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-cuda:9.2
+- condaforge/linux-anvil-cuda:10.2
 nccl:
 - 2.4.6.1
 pin_run_as_build:
@@ -28,7 +28,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- '3.6'
+- 3.7.* *_cpython
 zip_keys:
 - - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_cuda_compiler_version10.2python3.8.____cpython.yaml
+++ b/.ci_support/linux_cuda_compiler_version10.2python3.8.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '10.1'
+- '10.2'
 cudnn:
 - 7.6.5
 cxx_compiler:
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-cuda:10.1
+- condaforge/linux-anvil-cuda:10.2
 nccl:
 - 2.4.6.1
 pin_run_as_build:
@@ -28,7 +28,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- '3.6'
+- 3.8.* *_cpython
 zip_keys:
 - - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_cuda_compiler_version9.2python3.6.____cpython.yaml
+++ b/.ci_support/linux_cuda_compiler_version9.2python3.6.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '10.1'
+- '9.2'
 cudnn:
 - 7.6.5
 cxx_compiler:
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-cuda:10.1
+- condaforge/linux-anvil-cuda:9.2
 nccl:
 - 2.4.6.1
 pin_run_as_build:
@@ -28,7 +28,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- '3.7'
+- 3.6.* *_cpython
 zip_keys:
 - - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_cuda_compiler_version9.2python3.7.____cpython.yaml
+++ b/.ci_support/linux_cuda_compiler_version9.2python3.7.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '10.0'
+- '9.2'
 cudnn:
 - 7.6.5
 cxx_compiler:
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-cuda:10.0
+- condaforge/linux-anvil-cuda:9.2
 nccl:
 - 2.4.6.1
 pin_run_as_build:
@@ -28,7 +28,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- '3.7'
+- 3.7.* *_cpython
 zip_keys:
 - - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_cuda_compiler_version9.2python3.8.____cpython.yaml
+++ b/.ci_support/linux_cuda_compiler_version9.2python3.8.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '10.0'
+- '9.2'
 cudnn:
 - 7.6.5
 cxx_compiler:
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-cuda:10.0
+- condaforge/linux-anvil-cuda:9.2
 nccl:
 - 2.4.6.1
 pin_run_as_build:
@@ -28,7 +28,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- '3.8'
+- 3.8.* *_cpython
 zip_keys:
 - - cuda_compiler_version
   - docker_image

--- a/README.md
+++ b/README.md
@@ -29,87 +29,87 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_cuda_compiler_version10.0python3.6</td>
+              <td>linux_cuda_compiler_version10.0python3.6.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version10.0python3.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version10.0python3.6.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_cuda_compiler_version10.0python3.7</td>
+              <td>linux_cuda_compiler_version10.0python3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version10.0python3.7" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version10.0python3.7.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_cuda_compiler_version10.0python3.8</td>
+              <td>linux_cuda_compiler_version10.0python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version10.0python3.8" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version10.0python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_cuda_compiler_version10.1python3.6</td>
+              <td>linux_cuda_compiler_version10.1python3.6.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version10.1python3.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version10.1python3.6.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_cuda_compiler_version10.1python3.7</td>
+              <td>linux_cuda_compiler_version10.1python3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version10.1python3.7" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version10.1python3.7.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_cuda_compiler_version10.1python3.8</td>
+              <td>linux_cuda_compiler_version10.1python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version10.1python3.8" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version10.1python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_cuda_compiler_version10.2python3.6</td>
+              <td>linux_cuda_compiler_version10.2python3.6.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version10.2python3.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version10.2python3.6.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_cuda_compiler_version10.2python3.7</td>
+              <td>linux_cuda_compiler_version10.2python3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version10.2python3.7" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version10.2python3.7.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_cuda_compiler_version10.2python3.8</td>
+              <td>linux_cuda_compiler_version10.2python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version10.2python3.8" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version10.2python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_cuda_compiler_version9.2python3.6</td>
+              <td>linux_cuda_compiler_version9.2python3.6.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version9.2python3.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version9.2python3.6.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_cuda_compiler_version9.2python3.7</td>
+              <td>linux_cuda_compiler_version9.2python3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version9.2python3.7" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version9.2python3.7.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_cuda_compiler_version9.2python3.8</td>
+              <td>linux_cuda_compiler_version9.2python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version9.2python3.8" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version9.2python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/PR_3152.patch
+++ b/recipe/PR_3152.patch
@@ -1,0 +1,21 @@
+From 957f09ad12c3df0f97bd1db4d3f033faf44a3217 Mon Sep 17 00:00:00 2001
+From: John Kirkham <jakirkham@gmail.com>
+Date: Tue, 3 Mar 2020 22:24:19 -0800
+Subject: [PATCH] Readd `ndarray` type to `y`
+
+---
+ cupy/cuda/cub.pyx | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/cupy/cuda/cub.pyx b/cupy/cuda/cub.pyx
+index 9f4f844ded..6df8263b22 100644
+--- a/cupy/cuda/cub.pyx
++++ b/cupy/cuda/cub.pyx
+@@ -98,6 +98,7 @@ cpdef Py_ssize_t _preprocess_array(ndarray arr, tuple reduce_axis,
+ 
+ def device_reduce(ndarray x, op, tuple out_axis, out=None,
+                   bint keepdims=False):
++    cdef ndarray y
+     cdef memory.MemoryPointer ws
+     cdef int dtype_id, ndim_out, kv_bytes, x_size, _op
+     cdef size_t ws_size

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ build:
     - export CFLAGS="${CFLAGS} -I/usr/include"
     - export CPPFLAGS="${CPPFLAGS} -I/usr/include"
     - export CXXFLAGS="${CXXFLAGS} -I/usr/include"
-    #- export CUB_PATH=${PWD}/cub_v1.8.0  # TODO(leofang): remove this
+    - export CUB_PATH=${PWD}/cub_v1.8.0  # TODO(leofang): remove this
     - "{{ PYTHON }} -m pip install . -vv"
   missing_dso_whitelist:
     - "*/libcuda.*"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,12 +17,11 @@ source:
       #################################################
       - PR_3152.patch
 
-  # CUB support has too many bugs, let us wait for a bit longer   
-  ## 1. The CUB support has been extensively tested with v1.8.0, so we should pin it here
-  ## 2. This dependency should be removed once CuPy bundles CUB (cupy/cupy#2584)
-  #- url: https://github.com/NVlabs/cub/archive/v1.8.0.tar.gz
-  #  sha256: 025658f4c933cd2aa8cc88a559d013338d68de3fa639cc1f2b12cf61dc759667
-  #  folder: cub_v1.8.0  # so the source code is in cupy/cub_v1.8.0
+  # 1. The CUB support has been extensively tested with v1.8.0, so we should pin it here
+  # 2. This dependency should be removed once CuPy bundles CUB (cupy/cupy#2584)
+  - url: https://github.com/NVlabs/cub/archive/v1.8.0.tar.gz
+    sha256: 025658f4c933cd2aa8cc88a559d013338d68de3fa639cc1f2b12cf61dc759667
+    folder: cub_v1.8.0  # so the source code is in cupy/cub_v1.8.0
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
     folder: cub_v1.8.0  # so the source code is in cupy/cub_v1.8.0
 
 build:
-  number: 1
+  number: 2
   skip: True  # [py27 or (not linux64) or cuda_compiler_version == "None"]
   script:
     # CUDA 10.1 moves some headers to `/usr/include`

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,13 @@ package:
 source:
   - url: https://github.com/cupy/cupy/archive/v{{ version }}.tar.gz
     sha256: {{ sha256 }}
+    patches:
+      #################################################
+      # Include a bug-fix for CUB support.            #
+      #                                               #
+      # xref: https://github.com/cupy/cupy/pull/3152  #
+      #################################################
+      - PR_3152.patch
 
   # CUB support has too many bugs, let us wait for a bit longer   
   ## 1. The CUB support has been extensively tested with v1.8.0, so we should pin it here


### PR DESCRIPTION
Applies the patch from PR ( https://github.com/cupy/cupy/pull/3152 ) to 7.2.0 builds to fix the CUB issue and re-enable CUB support.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
