### PR TITLE
Tidy selectors

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ build:
   skip: True  # [py27]
   # temporarily disable PyPy build (conda-forge/cupy-feedstock#43)
   skip: True  # [python_impl == "pypy"]
-  skip: True  # [(not linux64) or cuda_compiler_version == "None"]
+  skip: True  # [cuda_compiler_version in (undefined, "None")]
   script:
     # CUDA 10.1 moves some headers to `/usr/include`
     # So add that location last in the header search paths

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,6 @@ source:
 
 build:
   number: 0
-  skip: True  # [py27]
   # temporarily disable PyPy build (conda-forge/cupy-feedstock#43)
   skip: True  # [python_impl == "pypy"]
   skip: True  # [cuda_compiler_version in (undefined, "None")]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,8 +22,10 @@ source:
 
 build:
   number: 0
+  skip: True  # [py27]
   # temporarily disable PyPy build (conda-forge/cupy-feedstock#43)
-  skip: True  # [py27 or (not linux64) or cuda_compiler_version == "None" or python_impl == 'pypy']
+  skip: True  # [python_impl == "pypy"]
+  skip: True  # [(not linux64) or cuda_compiler_version == "None"]
   script:
     # CUDA 10.1 moves some headers to `/usr/include`
     # So add that location last in the header search paths


### PR DESCRIPTION
Cleans up the selectors a bit to delineate the cases that we skip a bit more. Namely Python 2.7 is dropped in CuPy 7. PyPy has some issues (hopefully all now fixed upstream 🍀). Finally CUDA support is required to build.

As a last tweak, we now skip builds only when `cuda_compiler_version` is `undefined` or `None` (as opposed to skipping on `linux64` builds). This should make it trivial to add new architectures as CUDA builds become available for them without requiring changes here (outside of a re-render).

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Edit: Ignoring build number as this doesn't change how the packages are built.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
