### PR TITLE
Handle unset CUDA_PATH even when set -u option active

### DIFF
--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-if [[ $CUDA_PATH ]]; then
+if [[ -n ${CUDA_PATH:+x} ]]; then
     export CONDA_CUPY_CUDA_PATH=$CUDA_PATH
 fi
 

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-if [[ $CONDA_CUPY_CUDA_PATH ]]; then
+if [[ -n ${CONDA_CUPY_CUDA_PATH:+x} ]]; then
     export CUDA_PATH=$CONDA_CUPY_CUDA_PATH
     unset CONDA_CUPY_CUDA_PATH
 else

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
   #  folder: cub_v1.8.0  # so the source code is in cupy/cub_v1.8.0
 
 build:
-  number: 0
+  number: 1
   skip: true  # [cuda_compiler_version in (undefined, "None")]
   script:
     #- export CUB_PATH=${PWD}/cub_v1.8.0  # TODO(leofang): remove this


### PR DESCRIPTION
Fixes: #68

Test Plan:
  $ set -u
  $ conda activate test_cupy_path
  With fix applied we no longer get CUDA_PATH: unbound variable