### PR TITLE
Enable Windows + CUDA 11.2 build

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -44,6 +44,18 @@ jobs:
       win_64_cuda_compiler_version11.1python3.9.____cpython:
         CONFIG: win_64_cuda_compiler_version11.1python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compiler_version11.2python3.6.____cpython:
+        CONFIG: win_64_cuda_compiler_version11.2python3.6.____cpython
+        UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compiler_version11.2python3.7.____cpython:
+        CONFIG: win_64_cuda_compiler_version11.2python3.7.____cpython
+        UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compiler_version11.2python3.8.____cpython:
+        CONFIG: win_64_cuda_compiler_version11.2python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compiler_version11.2python3.9.____cpython:
+        CONFIG: win_64_cuda_compiler_version11.2python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\

--- a/.ci_support/win_64_cuda_compiler_version11.2python3.6.____cpython.yaml
+++ b/.ci_support/win_64_cuda_compiler_version11.2python3.6.____cpython.yaml
@@ -1,0 +1,24 @@
+c_compiler:
+- vs2017
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- nvcc
+cuda_compiler_version:
+- '11.2'
+cudnn:
+- '8'
+cutensor:
+- '1'
+cxx_compiler:
+- vs2017
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.6.* *_cpython
+target_platform:
+- win-64

--- a/.ci_support/win_64_cuda_compiler_version11.2python3.7.____cpython.yaml
+++ b/.ci_support/win_64_cuda_compiler_version11.2python3.7.____cpython.yaml
@@ -1,0 +1,24 @@
+c_compiler:
+- vs2017
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- nvcc
+cuda_compiler_version:
+- '11.2'
+cudnn:
+- '8'
+cutensor:
+- '1'
+cxx_compiler:
+- vs2017
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+target_platform:
+- win-64

--- a/.ci_support/win_64_cuda_compiler_version11.2python3.8.____cpython.yaml
+++ b/.ci_support/win_64_cuda_compiler_version11.2python3.8.____cpython.yaml
@@ -1,0 +1,24 @@
+c_compiler:
+- vs2017
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- nvcc
+cuda_compiler_version:
+- '11.2'
+cudnn:
+- '8'
+cutensor:
+- '1'
+cxx_compiler:
+- vs2017
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+target_platform:
+- win-64

--- a/.ci_support/win_64_cuda_compiler_version11.2python3.9.____cpython.yaml
+++ b/.ci_support/win_64_cuda_compiler_version11.2python3.9.____cpython.yaml
@@ -1,0 +1,24 @@
+c_compiler:
+- vs2017
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- nvcc
+cuda_compiler_version:
+- '11.2'
+cudnn:
+- '8'
+cutensor:
+- '1'
+cxx_compiler:
+- vs2017
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+target_platform:
+- win-64

--- a/README.md
+++ b/README.md
@@ -492,6 +492,34 @@ Current build status
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=master&jobName=win&configuration=win_64_cuda_compiler_version11.1python3.9.____cpython" alt="variant">
                 </a>
               </td>
+            </tr><tr>
+              <td>win_64_cuda_compiler_version11.2python3.6.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=master&jobName=win&configuration=win_64_cuda_compiler_version11.2python3.6.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compiler_version11.2python3.7.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=master&jobName=win&configuration=win_64_cuda_compiler_version11.2python3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compiler_version11.2python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=master&jobName=win&configuration=win_64_cuda_compiler_version11.2python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compiler_version11.2python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=master&jobName=win&configuration=win_64_cuda_compiler_version11.2python3.9.____cpython" alt="variant">
+                </a>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,1 +1,4 @@
 conda_forge_output_validation: true
+bot:
+  abi_migration_branches:
+    - rc

--- a/recipe/5002.diff
+++ b/recipe/5002.diff
@@ -1,0 +1,51 @@
+diff --git a/cupy/cuda/cupy_thrust.cu b/cupy/cuda/cupy_thrust.cu
+index f4e3910345..b1271814e9 100644
+--- a/cupy/cuda/cupy_thrust.cu
++++ b/cupy/cuda/cupy_thrust.cu
+@@ -6,6 +6,13 @@
+ #include <thrust/sort.h>
+ #include <thrust/tuple.h>
+ #include <thrust/execution_policy.h>
++#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2))
++// This is used to avoid a problem with constexpr in functions declarations introduced in
++// cuda 11.2, MSVC 15 does not fully support it so we need a dummy constexpr declaration
++// that is provided by this header. However optional.h is only available
++// starting CUDA 10.1
++#include <thrust/optional.h>
++#endif
+ #include "cupy_thrust.h"
+ 
+ 
+@@ -61,9 +68,7 @@ public:
+ template <typename T>
+ __host__ __device__ __forceinline__ 
+ #if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2))
+-#ifndef _WIN32
+-constexpr
+-#endif
++THRUST_OPTIONAL_CPP11_CONSTEXPR
+ #endif
+ bool _tuple_less(const tuple<size_t, T>& lhs,
+                                                      const tuple<size_t, T>& rhs) {
+@@ -95,9 +100,7 @@ bool _tuple_less(const tuple<size_t, T>& lhs,
+ template <typename T>
+ __host__ __device__ __forceinline__
+ #if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2))
+-#ifndef _WIN32
+-constexpr
+-#endif
++THRUST_OPTIONAL_CPP11_CONSTEXPR
+ #endif
+ bool _cmp_less(const T& lhs, const T& rhs) {
+     bool lhsRe = isnan(lhs.real());
+@@ -192,9 +195,7 @@ bool less< tuple<size_t, complex<double>> >::operator() (
+ template <typename T>
+ __host__ __device__ __forceinline__
+ #if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2))
+-#ifndef _WIN32
+-constexpr
+-#endif
++THRUST_OPTIONAL_CPP11_CONSTEXPR
+ #endif
+ bool _real_less(const T& lhs, const T& rhs) {
+     #if  (defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__))

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,11 +11,11 @@ source:
     sha256: {{ sha256 }}
     patches:
       - win64_detect_conda.diff  # [win]
+      - 5002.diff  # [win and cuda_compiler_version == "11.2"]
 
 build:
   number: 0
-  # TODO(leofang): fix the Thrust compiling error (C3615) for Windows + CUDA 11.2
-  skip: true  # [(not win64 and not linux64) or cuda_compiler_version in (undefined, "None") or (win64 and cuda_compiler_version == "11.2")]
+  skip: true  # [(not win64 and not linux64) or cuda_compiler_version in (undefined, "None")]
   script:
     # CuPy default detects CUDA from nvcc, but on Conda-Forge's dockers nvcc lives in a different place...
     # With conda-forge/nvcc-feedstock#58, CUDA_PATH is set correctly


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This is a manual backport of cupy/cupy#5002, as the v8 series is no longer maintained but it's just a matter of silencing the msvc compiler (hopefully) with no other impact. For the v9 series (currently the rc branch) we'll just wait for v9.0.0 in which the fix will land. 

The build number is purposely not bumped, as we are just expanding the build matrix without updating existing packages.

Close #115.