### PR TITLE
Rebuild to enable `libcugraph`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,7 +67,12 @@ build:
     {% endif %}
     {% if cuda_major_minor >= (10, 1) %}
     - libcugraph  # [linux64]
-    - librmm  # [linux64]  # libcugraph -> librmm -> (spdlog, thrust)
+    {% endif %}
+  ignore_run_exports:
+    {% if cuda_major_minor >= (10, 1) %}
+    # libcugraph -> librmm -> (spdlog, thrust)
+    - spdlog  # [linux64]
+    - thrust  # [linux64]
     {% endif %}
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,6 +67,7 @@ build:
     {% endif %}
     {% if cuda_major_minor >= (10, 1) %}
     - libcugraph  # [linux64]
+    - librmm  # [linux64]  # libcugraph -> librmm -> (spdlog, thrust)
     {% endif %}
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
     sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [(not win64 and not linux64) or cuda_compiler_version in (undefined, "None")]
   script:
     # CuPy default detects CUDA from nvcc, but on Conda-Forge's dockers nvcc lives in a different place...
@@ -33,10 +33,9 @@ build:
     {% if cuda_major == 11 %}
     - export CUSPARSELT_PATH=$PREFIX  # [linux64]
     {% endif %}
-    # blocked by conda-forge/libcugraph-feedstock#10
-    #{% if cuda_major_minor >= (10, 1) %}
-    #- export CUGRAPH_PATH=$PREFIX  # [linux64]
-    #{% endif %}
+    {% if cuda_major_minor >= (10, 1) %}
+    - export CUGRAPH_PATH=$PREFIX  # [linux64]
+    {% endif %}
 
     - {{ PYTHON }} -m pip install . --no-deps -vv
     - if errorlevel 1 exit 1  # [win]
@@ -66,9 +65,9 @@ build:
     {% if cuda_major == 11 %}
     - cusparselt  # [linux64]
     {% endif %}
-    #{% if cuda_major_minor >= (10, 1) %}
-    #- libcugraph  # [linux64]
-    #{% endif %}
+    {% if cuda_major_minor >= (10, 1) %}
+    - libcugraph  # [linux64]
+    {% endif %}
 
 requirements:
   build:
@@ -89,9 +88,9 @@ requirements:
     {% if cuda_major == 11 %}
     - cusparselt  # [linux64]
     {% endif %}
-    #{% if cuda_major_minor >= (10, 1) %}
-    #- libcugraph  # [linux64]
-    #{% endif %}
+    {% if cuda_major_minor >= (10, 1) %}
+    - libcugraph  # [linux64]
+    {% endif %}
 
   run:
     - python
@@ -110,9 +109,9 @@ requirements:
     {% if cuda_major == 11 %}
     - {{ pin_compatible('cusparselt') }}  # [linux64]
     {% endif %}
-    #{% if cuda_major_minor >= (10, 1) %}
-    #- {{ pin_compatible('libcugraph') }}  # [linux64]
-    #{% endif %}
+    {% if cuda_major_minor >= (10, 1) %}
+    - {{ pin_compatible('libcugraph') }}  # [linux64]
+    {% endif %}
 
 test:
   requires:


### PR DESCRIPTION
Close #112.

TODO: do not use CF's `thrust` package, as it's untested. 

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
