### PR TITLE
Fix `libcugraph` version pin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -123,7 +123,7 @@ requirements:
     - {{ pin_compatible('cusparselt', max_pin='x.x') }}  # [linux64 or win]
     {% endif %}
     {% if cuda_major_minor >= (10, 1) %}
-    - {{ pin_compatible('libcugraph') }}  # [linux64]
+    - libcugraph >=0.19.0  # [linux64]
     {% endif %}
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ source:
       - PR_5993.patch
 
 build:
-  number: 1
+  number: 2
   skip: true  # [(not win64 and not linux64 and (ppc64le and cuda_compiler_version != "10.2") and not (aarch64 and arm_variant_type == "sbsa")) or cuda_compiler_version in (undefined, "None")]
   script_env:
     # for some reason /usr/local/cuda is not added to $PATH in the docker image


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This PR loosens the `libcugraph` pin since `pin_compatible` computes to `>=0.19.0,<1.0a0`, which is incompatible with `libcugraph`'s new calendar versioning (i.e. `21.xx`).