### PR TITLE
Unify treatments in optional requirements to handle the `__cuda` constraint correctly

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ source:
       - support_nvtx3_win.diff        # [win64]
 
 build:
-  number: 2
+  number: 3
   # TODO: turn on win64 + CUDA 12 once it's ready
   skip: true  # [cuda_compiler_version not in ("11.8", "12.0") or (cuda_compiler_version == "12.0" and win64)]
   script:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,6 +70,8 @@ build:
     - '*/libcuda.*'  # [linux]
     - '*/nvcuda.dll'  # [win]
   ignore_run_exports:
+    # the driver requirement is explicitly overwritten below
+    - __cuda
     # optional dependencies
     - cudnn       # [not ((aarch64 or ppc64le) and (cuda_compiler_version or "").startswith("12"))]
     - nccl        # [linux]
@@ -147,6 +149,8 @@ requirements:
     - __glibc >=2.17  # [linux]
     - scipy >=1.7,<2
     - optuna >=3,<4
+    - __cuda >=11.2  # [(cuda_compiler_version or "").startswith("11")]
+    - __cuda >=12.0  # [(cuda_compiler_version or "").startswith("12")]
     # TODO: Waiting for `aarch64` & `ppc64le` CUDA 12 support
     - {{ pin_compatible('cudnn') }}                        # [not ((aarch64 or ppc64le) and (cuda_compiler_version or "").startswith("12"))]
     - {{ pin_compatible('nccl') }}                         # [linux]


### PR DESCRIPTION
Previously, we inherited the `__cuda` constraint from the CUDA compiler. Since it's a driver constraint and we actually relaxed it with the CUDA 11.8 migration (#226), it should have been taken care of too, and this PR fixes it. 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
