### PR TITLE
Turn down build parallelism to reduce memory usage on CI

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -96,7 +96,7 @@ outputs:
         # Do this by prepending to the CL environment variable.
         # ref: https://learn.microsoft.com/en-us/cpp/build/reference/cgthreads-compiler-threads?view=msvc-170
         # ref: https://learn.microsoft.com/en-us/cpp/build/reference/cl-environment-variables?view=msvc-170
-        - set CL=/cgthreads:2 %CL%                                                   # [win]
+        - set CL=/cgthreads2 %CL%                                                    # [win]
         {% if cuda_major >= 12 %}
         - export CUDA_PATH=$PREFIX/targets/{{ target_name }}                         # [linux]
         {% endif %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -88,7 +88,7 @@ outputs:
         # CuPy default detects CUDA from nvcc, but on Conda-Forge's dockers nvcc lives in a different place...
         # With conda-forge/nvcc-feedstock#58, CUDA_PATH is set correctly
         - export NVCC="$(which nvcc)"                                                # [linux]
-        - export CUPY_NUM_BUILD_JOBS=1                                               # [aarch64 or ppc64le or (linux64 and cuda_compiler == "nvcc")]
+        - export CUPY_NUM_BUILD_JOBS=1
         {% if cuda_major >= 12 %}
         - export CUDA_PATH=$PREFIX/targets/{{ target_name }}                         # [linux]
         {% endif %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -84,6 +84,10 @@ outputs:
       number: {{ number }}
       # For CUDA 12, the compiler version is hard-coded in the cuda120.yaml migrator
       skip: true  # [(py < 39) or cuda_compiler_version not in ("11.8", "12.8") or ppc64le]
+      script_env:
+        # To avoid memory usage warnings on CI, reduce parallelism of CuPy builds.
+        - CUPY_NUM_NVCC_THREADS=1                                                    # [win]
+        - CUPY_NUM_BUILD_JOBS=1
       script:
         # CuPy default detects CUDA from nvcc, but on Conda-Forge's dockers nvcc lives in a different place...
         # With conda-forge/nvcc-feedstock#58, CUDA_PATH is set correctly
@@ -93,8 +97,6 @@ outputs:
         # ref: https://learn.microsoft.com/en-us/cpp/build/reference/cgthreads-compiler-threads?view=msvc-170
         # ref: https://learn.microsoft.com/en-us/cpp/build/reference/cl-environment-variables?view=msvc-170
         - set CL=/cgthreads:2 %CL%                                                   # [win]
-        - export CUPY_NUM_NVCC_THREADS=1                                             # [win]
-        - export CUPY_NUM_BUILD_JOBS=1
         {% if cuda_major >= 12 %}
         - export CUDA_PATH=$PREFIX/targets/{{ target_name }}                         # [linux]
         {% endif %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -86,17 +86,11 @@ outputs:
       skip: true  # [(py < 39) or cuda_compiler_version not in ("11.8", "12.8") or ppc64le]
       script_env:
         # To avoid memory usage warnings on CI, reduce parallelism of CuPy builds.
-        - CUPY_NUM_NVCC_THREADS=1                                                    # [win]
         - CUPY_NUM_BUILD_JOBS=1
       script:
         # CuPy default detects CUDA from nvcc, but on Conda-Forge's dockers nvcc lives in a different place...
         # With conda-forge/nvcc-feedstock#58, CUDA_PATH is set correctly
         - export NVCC="$(which nvcc)"                                                # [linux]
-        # Configure the Windows compiler `cl` to reduce threads from 4 to 2.
-        # Do this by prepending to the CL environment variable.
-        # ref: https://learn.microsoft.com/en-us/cpp/build/reference/cgthreads-compiler-threads?view=msvc-170
-        # ref: https://learn.microsoft.com/en-us/cpp/build/reference/cl-environment-variables?view=msvc-170
-        - set CL=/cgthreads2 %CL%                                                    # [win]
         {% if cuda_major >= 12 %}
         - export CUDA_PATH=$PREFIX/targets/{{ target_name }}                         # [linux]
         {% endif %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -88,6 +88,11 @@ outputs:
         # CuPy default detects CUDA from nvcc, but on Conda-Forge's dockers nvcc lives in a different place...
         # With conda-forge/nvcc-feedstock#58, CUDA_PATH is set correctly
         - export NVCC="$(which nvcc)"                                                # [linux]
+        # Configure the Windows compiler `cl` to reduce threads from 4 to 2.
+        # Do this by prepending to the CL environment variable.
+        # ref: https://learn.microsoft.com/en-us/cpp/build/reference/cgthreads-compiler-threads?view=msvc-170
+        # ref: https://learn.microsoft.com/en-us/cpp/build/reference/cl-environment-variables?view=msvc-170
+        - set CL=/cgthreads:2 %CL%                                                   # [win]
         - export CUPY_NUM_NVCC_THREADS=1                                             # [win]
         - export CUPY_NUM_BUILD_JOBS=1
         {% if cuda_major >= 12 %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -88,6 +88,7 @@ outputs:
         # CuPy default detects CUDA from nvcc, but on Conda-Forge's dockers nvcc lives in a different place...
         # With conda-forge/nvcc-feedstock#58, CUDA_PATH is set correctly
         - export NVCC="$(which nvcc)"                                                # [linux]
+        - export CUPY_NUM_NVCC_THREADS=1                                             # [win]
         - export CUPY_NUM_BUILD_JOBS=1
         {% if cuda_major >= 12 %}
         - export CUDA_PATH=$PREFIX/targets/{{ target_name }}                         # [linux]


### PR DESCRIPTION
To address the memory usage warnings on Azure ( https://github.com/conda-forge/cupy-feedstock/issues/301 ), reduce build parallelism:

* Reduce build jobs from 4 to 1 for all builds by setting [`CUPY_NUM_BUILD_JOBS`]( https://docs.cupy.dev/en/stable/reference/environment.html#envvar-CUPY_NUM_BUILD_JOBS ) to 1 (default was 4)

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes https://github.com/conda-forge/cupy-feedstock/issues/301

<!--
Please add any other relevant info below:
-->
