### PR TITLE
Migrate to Python 3.14 & re-enable optional dependencies for CUDA 13 builds

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -24,6 +24,10 @@ jobs:
         CONFIG: linux_64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.13.____cp313
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.14.____cp314:
+        CONFIG: linux_64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.14.____cp314
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.10.____cpython:
         CONFIG: linux_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -38,6 +42,10 @@ jobs:
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.13.____cp313:
         CONFIG: linux_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.13.____cp313
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.14.____cp314:
+        CONFIG: linux_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.14.____cp314
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_64_cuda_compilernvcccuda_compiler_version11.8python3.10.____cpython:
@@ -56,6 +64,10 @@ jobs:
         CONFIG: linux_64_cuda_compilernvcccuda_compiler_version11.8python3.13.____cp313
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64-cuda11.8:ubi8
+      linux_64_cuda_compilernvcccuda_compiler_version11.8python3.14.____cp314:
+        CONFIG: linux_64_cuda_compilernvcccuda_compiler_version11.8python3.14.____cp314
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64-cuda11.8:ubi8
       linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.10.____cpython:
         CONFIG: linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -70,6 +82,10 @@ jobs:
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.13.____cp313:
         CONFIG: linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.13.____cp313
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.14.____cp314:
+        CONFIG: linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.14.____cp314
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.10.____cpython:
@@ -88,6 +104,10 @@ jobs:
         CONFIG: linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.13.____cp313
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.14.____cp314:
+        CONFIG: linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.14.____cp314
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_cuda_compilernvcccuda_compiler_version11.8python3.10.____cpython:
         CONFIG: linux_aarch64_cuda_compilernvcccuda_compiler_version11.8python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -102,6 +122,10 @@ jobs:
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64-cuda11.8:ubi8
       linux_aarch64_cuda_compilernvcccuda_compiler_version11.8python3.13.____cp313:
         CONFIG: linux_aarch64_cuda_compilernvcccuda_compiler_version11.8python3.13.____cp313
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64-cuda11.8:ubi8
+      linux_aarch64_cuda_compilernvcccuda_compiler_version11.8python3.14.____cp314:
+        CONFIG: linux_aarch64_cuda_compilernvcccuda_compiler_version11.8python3.14.____cp314
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64-cuda11.8:ubi8
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -20,6 +20,9 @@ jobs:
       win_64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.13.____cp313:
         CONFIG: win_64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.13.____cp313
         UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.14.____cp314:
+        CONFIG: win_64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.14.____cp314
+        UPLOAD_PACKAGES: 'True'
       win_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.10.____cpython:
         CONFIG: win_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -32,6 +35,9 @@ jobs:
       win_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.13.____cp313:
         CONFIG: win_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.13.____cp313
         UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.14.____cp314:
+        CONFIG: win_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.14.____cp314
+        UPLOAD_PACKAGES: 'True'
       win_64_cuda_compilernvcccuda_compiler_version11.8python3.10.____cpython:
         CONFIG: win_64_cuda_compilernvcccuda_compiler_version11.8python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -43,6 +49,9 @@ jobs:
         UPLOAD_PACKAGES: 'True'
       win_64_cuda_compilernvcccuda_compiler_version11.8python3.13.____cp313:
         CONFIG: win_64_cuda_compilernvcccuda_compiler_version11.8python3.13.____cp313
+        UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compilernvcccuda_compiler_version11.8python3.14.____cp314:
+        CONFIG: win_64_cuda_compilernvcccuda_compiler_version11.8python3.14.____cp314
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables:

--- a/.ci_support/linux_64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.10.____cpython.yaml
@@ -41,3 +41,5 @@ zip_keys:
   - cuda_compiler_version
   - cuda_compiler
   - docker_image
+- - python
+  - channel_sources

--- a/.ci_support/linux_64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.11.____cpython.yaml
@@ -41,3 +41,5 @@ zip_keys:
   - cuda_compiler_version
   - cuda_compiler
   - docker_image
+- - python
+  - channel_sources

--- a/.ci_support/linux_64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.12.____cpython.yaml
@@ -41,3 +41,5 @@ zip_keys:
   - cuda_compiler_version
   - cuda_compiler
   - docker_image
+- - python
+  - channel_sources

--- a/.ci_support/linux_64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.13.____cp313.yaml
@@ -41,3 +41,5 @@ zip_keys:
   - cuda_compiler_version
   - cuda_compiler
   - docker_image
+- - python
+  - channel_sources

--- a/.ci_support/linux_64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.14.____cp314.yaml
+++ b/.ci_support/linux_64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.14.____cp314.yaml
@@ -5,17 +5,17 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.28'
+- '2.17'
 cdt_name:
 - conda
 channel_sources:
-- conda-forge
+- conda-forge,conda-forge/label/python_rc
 channel_targets:
 - conda-forge main
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '13.0'
+- '12.9'
 cutensor:
 - '2'
 cxx_compiler:
@@ -31,7 +31,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.14.* *_cp314
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.10.____cpython.yaml
@@ -41,3 +41,5 @@ zip_keys:
   - cuda_compiler_version
   - cuda_compiler
   - docker_image
+- - python
+  - channel_sources

--- a/.ci_support/linux_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.11.____cpython.yaml
@@ -41,3 +41,5 @@ zip_keys:
   - cuda_compiler_version
   - cuda_compiler
   - docker_image
+- - python
+  - channel_sources

--- a/.ci_support/linux_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.13.____cp313.yaml
@@ -41,3 +41,5 @@ zip_keys:
   - cuda_compiler_version
   - cuda_compiler
   - docker_image
+- - python
+  - channel_sources

--- a/.ci_support/linux_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.14.____cp314.yaml
+++ b/.ci_support/linux_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.14.____cp314.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - conda
 channel_sources:
-- conda-forge
+- conda-forge,conda-forge/label/python_rc
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -31,7 +31,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.14.* *_cp314
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_cuda_compilernvcccuda_compiler_version11.8python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_cuda_compilernvcccuda_compiler_version11.8python3.10.____cpython.yaml
@@ -41,3 +41,5 @@ zip_keys:
   - cuda_compiler_version
   - cuda_compiler
   - docker_image
+- - python
+  - channel_sources

--- a/.ci_support/linux_64_cuda_compilernvcccuda_compiler_version11.8python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_cuda_compilernvcccuda_compiler_version11.8python3.11.____cpython.yaml
@@ -41,3 +41,5 @@ zip_keys:
   - cuda_compiler_version
   - cuda_compiler
   - docker_image
+- - python
+  - channel_sources

--- a/.ci_support/linux_64_cuda_compilernvcccuda_compiler_version11.8python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_cuda_compilernvcccuda_compiler_version11.8python3.12.____cpython.yaml
@@ -41,3 +41,5 @@ zip_keys:
   - cuda_compiler_version
   - cuda_compiler
   - docker_image
+- - python
+  - channel_sources

--- a/.ci_support/linux_64_cuda_compilernvcccuda_compiler_version11.8python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_cuda_compilernvcccuda_compiler_version11.8python3.13.____cp313.yaml
@@ -41,3 +41,5 @@ zip_keys:
   - cuda_compiler_version
   - cuda_compiler
   - docker_image
+- - python
+  - channel_sources

--- a/.ci_support/linux_64_cuda_compilernvcccuda_compiler_version11.8python3.14.____cp314.yaml
+++ b/.ci_support/linux_64_cuda_compilernvcccuda_compiler_version11.8python3.14.____cp314.yaml
@@ -1,29 +1,29 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '14'
+- '11'
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.28'
+- '2.17'
 cdt_name:
 - conda
 channel_sources:
-- conda-forge
+- conda-forge,conda-forge/label/python_rc
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- cuda-nvcc
+- nvcc
 cuda_compiler_version:
-- '13.0'
+- '11.8'
 cutensor:
 - '2'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '14'
+- '11'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64-cuda11.8:ubi8
 nccl:
 - '2'
 pin_run_as_build:
@@ -31,7 +31,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.14.* *_cp314
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.10.____cpython.yaml
@@ -41,3 +41,5 @@ zip_keys:
   - cuda_compiler_version
   - cuda_compiler
   - docker_image
+- - python
+  - channel_sources

--- a/.ci_support/linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.11.____cpython.yaml
@@ -41,3 +41,5 @@ zip_keys:
   - cuda_compiler_version
   - cuda_compiler
   - docker_image
+- - python
+  - channel_sources

--- a/.ci_support/linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.12.____cpython.yaml
@@ -41,3 +41,5 @@ zip_keys:
   - cuda_compiler_version
   - cuda_compiler
   - docker_image
+- - python
+  - channel_sources

--- a/.ci_support/linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.13.____cp313.yaml
@@ -41,3 +41,5 @@ zip_keys:
   - cuda_compiler_version
   - cuda_compiler
   - docker_image
+- - python
+  - channel_sources

--- a/.ci_support/linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.14.____cp314.yaml
+++ b/.ci_support/linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.14.____cp314.yaml
@@ -5,17 +5,17 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.28'
+- '2.17'
 cdt_name:
 - conda
 channel_sources:
-- conda-forge
+- conda-forge,conda-forge/label/python_rc
 channel_targets:
 - conda-forge main
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '13.0'
+- '12.9'
 cutensor:
 - '2'
 cxx_compiler:
@@ -31,9 +31,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.14.* *_cp314
 target_platform:
-- linux-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.10.____cpython.yaml
@@ -41,3 +41,5 @@ zip_keys:
   - cuda_compiler_version
   - cuda_compiler
   - docker_image
+- - python
+  - channel_sources

--- a/.ci_support/linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.11.____cpython.yaml
@@ -41,3 +41,5 @@ zip_keys:
   - cuda_compiler_version
   - cuda_compiler
   - docker_image
+- - python
+  - channel_sources

--- a/.ci_support/linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.12.____cpython.yaml
@@ -41,3 +41,5 @@ zip_keys:
   - cuda_compiler_version
   - cuda_compiler
   - docker_image
+- - python
+  - channel_sources

--- a/.ci_support/linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.13.____cp313.yaml
@@ -41,3 +41,5 @@ zip_keys:
   - cuda_compiler_version
   - cuda_compiler
   - docker_image
+- - python
+  - channel_sources

--- a/.ci_support/linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.14.____cp314.yaml
+++ b/.ci_support/linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.14.____cp314.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - conda
 channel_sources:
-- conda-forge
+- conda-forge,conda-forge/label/python_rc
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -31,9 +31,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.14.* *_cp314
 target_platform:
-- linux-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_cuda_compilernvcccuda_compiler_version11.8python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compilernvcccuda_compiler_version11.8python3.10.____cpython.yaml
@@ -41,3 +41,5 @@ zip_keys:
   - cuda_compiler_version
   - cuda_compiler
   - docker_image
+- - python
+  - channel_sources

--- a/.ci_support/linux_aarch64_cuda_compilernvcccuda_compiler_version11.8python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compilernvcccuda_compiler_version11.8python3.11.____cpython.yaml
@@ -41,3 +41,5 @@ zip_keys:
   - cuda_compiler_version
   - cuda_compiler
   - docker_image
+- - python
+  - channel_sources

--- a/.ci_support/linux_aarch64_cuda_compilernvcccuda_compiler_version11.8python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compilernvcccuda_compiler_version11.8python3.12.____cpython.yaml
@@ -41,3 +41,5 @@ zip_keys:
   - cuda_compiler_version
   - cuda_compiler
   - docker_image
+- - python
+  - channel_sources

--- a/.ci_support/linux_aarch64_cuda_compilernvcccuda_compiler_version11.8python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_cuda_compilernvcccuda_compiler_version11.8python3.13.____cp313.yaml
@@ -41,3 +41,5 @@ zip_keys:
   - cuda_compiler_version
   - cuda_compiler
   - docker_image
+- - python
+  - channel_sources

--- a/.ci_support/linux_aarch64_cuda_compilernvcccuda_compiler_version11.8python3.14.____cp314.yaml
+++ b/.ci_support/linux_aarch64_cuda_compilernvcccuda_compiler_version11.8python3.14.____cp314.yaml
@@ -1,29 +1,29 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '14'
+- '11'
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.28'
+- '2.17'
 cdt_name:
 - conda
 channel_sources:
-- conda-forge
+- conda-forge,conda-forge/label/python_rc
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- cuda-nvcc
+- nvcc
 cuda_compiler_version:
-- '13.0'
+- '11.8'
 cutensor:
 - '2'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '14'
+- '11'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64-cuda11.8:ubi8
 nccl:
 - '2'
 pin_run_as_build:
@@ -31,9 +31,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.14.* *_cp314
 target_platform:
-- linux-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/migrations/python314.yaml
+++ b/.ci_support/migrations/python314.yaml
@@ -1,0 +1,43 @@
+# this is intentionally sorted before the 3.13t migrator, because that determines
+# the order of application of the migrators; otherwise we'd have to add values for
+# is_freethreading and is_abi3 keys here, since that migration extends the zip;
+migrator_ts: 1724712607
+__migrator:
+    commit_message: Rebuild for python 3.14
+    migration_number: 1
+    operation: key_add
+    primary_key: python
+    ordering:
+        python:
+            - 3.9.* *_cpython
+            - 3.10.* *_cpython
+            - 3.11.* *_cpython
+            - 3.12.* *_cpython
+            - 3.13.* *_cp313
+            - 3.13.* *_cp313t
+            - 3.14.* *_cp314  # new entry
+    paused: false
+    longterm: true
+    pr_limit: 5
+    max_solver_attempts: 3  # this will make the bot retry "not solvable" stuff 12 times
+    exclude:
+        # this shouldn't attempt to modify the python feedstocks
+        - python
+        - pypy3.6
+        - pypy-meta
+        - cross-python
+        - python_abi
+    exclude_pinned_pkgs: false
+    ignored_deps_per_node:
+        matplotlib:
+            - pyqt
+    additional_zip_keys:
+        - channel_sources
+
+python:
+- 3.14.* *_cp314
+# additional entries to add for zip_keys
+is_python_min:
+- false
+channel_sources:
+- conda-forge,conda-forge/label/python_rc

--- a/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.10.____cpython.yaml
+++ b/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.10.____cpython.yaml
@@ -25,3 +25,5 @@ target_platform:
 zip_keys:
 - - cuda_compiler_version
   - cuda_compiler
+- - python
+  - channel_sources

--- a/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.11.____cpython.yaml
+++ b/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.11.____cpython.yaml
@@ -25,3 +25,5 @@ target_platform:
 zip_keys:
 - - cuda_compiler_version
   - cuda_compiler
+- - python
+  - channel_sources

--- a/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.12.____cpython.yaml
+++ b/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.12.____cpython.yaml
@@ -25,3 +25,5 @@ target_platform:
 zip_keys:
 - - cuda_compiler_version
   - cuda_compiler
+- - python
+  - channel_sources

--- a/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.13.____cp313.yaml
+++ b/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.13.____cp313.yaml
@@ -25,3 +25,5 @@ target_platform:
 zip_keys:
 - - cuda_compiler_version
   - cuda_compiler
+- - python
+  - channel_sources

--- a/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.14.____cp314.yaml
+++ b/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.14.____cp314.yaml
@@ -3,13 +3,13 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge
+- conda-forge,conda-forge/label/python_rc
 channel_targets:
 - conda-forge main
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '13.0'
+- '12.9'
 cutensor:
 - '2'
 cxx_compiler:
@@ -19,7 +19,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.11.* *_cpython
+- 3.14.* *_cp314
 target_platform:
 - win-64
 zip_keys:

--- a/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.10.____cpython.yaml
+++ b/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.10.____cpython.yaml
@@ -25,3 +25,5 @@ target_platform:
 zip_keys:
 - - cuda_compiler_version
   - cuda_compiler
+- - python
+  - channel_sources

--- a/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.12.____cpython.yaml
+++ b/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.12.____cpython.yaml
@@ -25,3 +25,5 @@ target_platform:
 zip_keys:
 - - cuda_compiler_version
   - cuda_compiler
+- - python
+  - channel_sources

--- a/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.13.____cp313.yaml
+++ b/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.13.____cp313.yaml
@@ -25,3 +25,5 @@ target_platform:
 zip_keys:
 - - cuda_compiler_version
   - cuda_compiler
+- - python
+  - channel_sources

--- a/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.14.____cp314.yaml
+++ b/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.14.____cp314.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge
+- conda-forge,conda-forge/label/python_rc
 channel_targets:
 - conda-forge main
 cuda_compiler:
@@ -19,7 +19,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.11.* *_cpython
+- 3.14.* *_cp314
 target_platform:
 - win-64
 zip_keys:

--- a/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8python3.10.____cpython.yaml
+++ b/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8python3.10.____cpython.yaml
@@ -25,3 +25,5 @@ target_platform:
 zip_keys:
 - - cuda_compiler_version
   - cuda_compiler
+- - python
+  - channel_sources

--- a/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8python3.11.____cpython.yaml
+++ b/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8python3.11.____cpython.yaml
@@ -25,3 +25,5 @@ target_platform:
 zip_keys:
 - - cuda_compiler_version
   - cuda_compiler
+- - python
+  - channel_sources

--- a/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8python3.12.____cpython.yaml
+++ b/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8python3.12.____cpython.yaml
@@ -25,3 +25,5 @@ target_platform:
 zip_keys:
 - - cuda_compiler_version
   - cuda_compiler
+- - python
+  - channel_sources

--- a/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8python3.13.____cp313.yaml
+++ b/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8python3.13.____cp313.yaml
@@ -25,3 +25,5 @@ target_platform:
 zip_keys:
 - - cuda_compiler_version
   - cuda_compiler
+- - python
+  - channel_sources

--- a/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8python3.14.____cp314.yaml
+++ b/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8python3.14.____cp314.yaml
@@ -3,13 +3,13 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge
+- conda-forge,conda-forge/label/python_rc
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- cuda-nvcc
+- nvcc
 cuda_compiler_version:
-- '13.0'
+- '11.8'
 cutensor:
 - '2'
 cxx_compiler:
@@ -19,7 +19,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.11.* *_cpython
+- 3.14.* *_cp314
 target_platform:
 - win-64
 zip_keys:

--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.14.____cp314</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.14.____cp314" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=main">
@@ -107,6 +114,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.14.____cp314</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.14.____cp314" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -138,6 +152,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_64_cuda_compilernvcccuda_compiler_version11.8python3.14.____cp314</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cuda_compilernvcccuda_compiler_version11.8python3.14.____cp314" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=main">
@@ -163,6 +184,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.14.____cp314</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.14.____cp314" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -194,6 +222,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.14.____cp314</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.14.____cp314" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_aarch64_cuda_compilernvcccuda_compiler_version11.8python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=main">
@@ -219,6 +254,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compilernvcccuda_compiler_version11.8python3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_cuda_compilernvcccuda_compiler_version11.8python3.14.____cp314</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compilernvcccuda_compiler_version11.8python3.14.____cp314" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -250,6 +292,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>win_64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.14.____cp314</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compilercuda-nvcccuda_compiler_version12.9python3.14.____cp314" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>win_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=main">
@@ -278,6 +327,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>win_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.14.____cp314</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compilercuda-nvcccuda_compiler_version13.0python3.14.____cp314" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>win_64_cuda_compilernvcccuda_compiler_version11.8python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=main">
@@ -303,6 +359,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compilernvcccuda_compiler_version11.8python3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compilernvcccuda_compiler_version11.8python3.14.____cp314</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8275&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cupy-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compilernvcccuda_compiler_version11.8python3.14.____cp314" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "cupy" %}
 {% set version = "13.6.0" %}
 {% set sha256 = "3cba30ae3dd32b5d5c6536e710cb98015227cd4ba83c46b3f1825a7ae55b6667" %}
-{% set number = 1 %}
+{% set number = 2 %}
 
 {% set target_name = "x86_64-linux" %}  # [linux64]
 {% set target_name = "ppc64le-linux" %}  # [ppc64le]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -197,7 +197,7 @@ outputs:
       run:
         - python
         - {{ pin_compatible('fastrlock', max_pin='x.x') }}
-        - numpy >=1.22,<2.3
+        - numpy >=1.22
       run_constrained:
         # we move these here so that cupy-core can be installed in CPU-only envs
         - {{ pin_compatible("cuda-version", lower_bound="11.2") }}            # [cuda_compiler == "nvcc"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -136,10 +136,8 @@ outputs:
         {% endif %}
       ignore_run_exports:
         # optional dependencies
-        {% if cuda_major < 13 %}
         - nccl        # [linux]
         - cutensor
-        {% endif %}
     requirements:
       build:
         - {{ compiler("c") }}
@@ -164,10 +162,8 @@ outputs:
         - libcusparse-dev                       # [build_platform != target_platform]
         {% endif %}
         # optional dependencies for CUDA 11.2+
-        {% if cuda_major < 13 %}
         - nccl ~=2.16                           # [build_platform != target_platform]
         - cutensor ~=2.0                        # [build_platform != target_platform]
-        {% endif %}
       host:
         - python
         - pip
@@ -190,10 +186,8 @@ outputs:
         - libcusparse-dev
         {% endif %}
         # optional dependencies
-        {% if cuda_major < 13 %}
         - nccl ~=2.16           # [linux]
         - cutensor ~=2.0
-        {% endif %}
       run:
         - python
         - {{ pin_compatible('fastrlock', max_pin='x.x') }}
@@ -214,10 +208,8 @@ outputs:
         - __cuda >={{ cuda_major }}.2                            # [cuda_compiler == "nvcc"]
         - __cuda >={{ cuda_major }}.0                            # [cuda_compiler == "cuda-nvcc"]
         - {{ pin_subpackage('cupy', max_pin='x.x') }}
-        {% if cuda_major < 13 %}
         - {{ pin_compatible('nccl') }}                           # [linux]
         - {{ pin_compatible('cutensor') }}
-        {% endif %}
     test:
       requires:
         - pip


### PR DESCRIPTION
Close #316. Close #317.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
