### PR TITLE
[ci skip] ***NO_CI*** Update maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @asi1024 @emcastillo @jakirkham @kmaehashi @leofang @toslunar
+* @asi1024 @emcastillo @jakirkham @kmaehashi @leofang

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -241,4 +241,3 @@ extra:
     - kmaehashi
     - asi1024
     - emcastillo
-    - toslunar


### PR DESCRIPTION
Updated the list of CODEOWNERS and recipe maintainers.